### PR TITLE
build(action): add multi-platform build and push workflow Docker Buildx v6

### DIFF
--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -45,6 +45,11 @@ on:
         default: false
         required: false
         type: boolean
+      docker-build-timeout-minutes:
+        description: 'docker build timeout minutes'
+        default: 30
+        required: false
+        type: number
     secrets:
       DOCKERHUB_TOKEN:
         description: 'docker hub token'
@@ -144,13 +149,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
+        timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -1,4 +1,4 @@
-## will push to dockerhub
+## will push to dockerhub and ghcr.io
 # this is a workflow must add
 # - variables `ENV_DOCKERHUB_OWNER` user of docker hub
 # - variables `ENV_DOCKERHUB_REPO_NAME` repo name of docker hub
@@ -6,16 +6,20 @@
 # add config file at `./docker-bake.hcl` or change input `docker_bake_config_file_path`
 # most use as: github.event.pull_request.merged == true
 
-name: docker-buildx-bake-hubdocker-latest
+name: docker-buildx-bake-multi-latest
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-${{ inputs.docker_bake_targets }}-latest
+  group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-multi-${{ inputs.docker_bake_targets }}-latest
   # cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
   cancel-in-progress: false
 
 on:
   workflow_call: # https://docs.github.com/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow
     inputs:
+      ghcr_package_owner_name:
+        description: 'GHCR package owner name'
+        required: true
+        type: string
       push_remote_flag:
         description: 'flag for push to remote'
         default: false
@@ -59,6 +63,7 @@ on:
 permissions: # https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#permissions
   contents: write
   discussions: write
+  packages: write
 
 jobs:
   prepare:
@@ -106,6 +111,7 @@ jobs:
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
+            ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
           tags: |
             # set latest tag for main branch https://github.com/docker/metadata-action#latest-tag
             type=raw,value=latest,enable=true
@@ -150,6 +156,15 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        if: ${{ inputs.push_remote_flag }}
+        with:
+          registry: ghcr.io
+          username: ${{ inputs.ghcr_package_owner_name }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
         name: check build files
         run: |
           echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
@@ -176,7 +191,7 @@ jobs:
             *.platform=${{ matrix.platform }}
             *.cache-from=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
             *.cache-to=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
-            *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
+            *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }},ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
 
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
@@ -260,13 +275,24 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ inputs.ghcr_package_owner_name }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
           docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+            $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
           tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
+          docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -1,24 +1,27 @@
-## will push to dockerhub
+## will push to dockerhub and ghcr.io
 # this is a workflow must add
 # - variables `ENV_DOCKERHUB_OWNER` user of docker hub
 # - variables `ENV_DOCKERHUB_REPO_NAME` repo name of docker hub
 # - secrets `DOCKERHUB_TOKEN` token of docker hub user from [hub.docker](https://hub.docker.com/settings/security)
 # add config file at `./docker-bake.hcl` or change input `docker_bake_config_file_path`
-# most use as: github.event.pull_request.merged == true
+# most use as: startsWith(github.ref, 'refs/tags/')
 
-name: docker-buildx-bake-hubdocker-latest
+name: docker-buildx-bake-multi-tag
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-hubdocker-${{ inputs.docker_bake_targets }}-latest
-  # cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-  cancel-in-progress: false
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}-docker-buildx-bake-multi-${{ inputs.docker_bake_targets }}-tag
+#   cancel-in-progress: false
 
 on:
   workflow_call: # https://docs.github.com/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow
     inputs:
+      ghcr_package_owner_name:
+        description: 'GHCR package owner name'
+        required: true
+        type: string
       push_remote_flag:
         description: 'flag for push to remote'
-        default: false
+        default: true
         required: false
         type: boolean
       docker_bake_targets:
@@ -59,6 +62,7 @@ on:
 permissions: # https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#permissions
   contents: write
   discussions: write
+  packages: write
 
 jobs:
   prepare:
@@ -106,13 +110,13 @@ jobs:
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
+            ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
           tags: |
-            # set latest tag for main branch https://github.com/docker/metadata-action#latest-tag
-            type=raw,value=latest,enable=true
+            # type semver https://github.com/docker/metadata-action#typesemver
+            type=semver,pattern={{version}}
           flavor: |
             latest=auto
             suffix=${{ inputs.docker-metadata-flavor-suffix }}
-
       -
         name: Rename meta bake definition file
         run: |
@@ -124,7 +128,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
@@ -148,6 +152,15 @@ jobs:
         with:
           username: ${{ vars.ENV_DOCKERHUB_OWNER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        if: ${{ inputs.push_remote_flag }}
+        with:
+          registry: ghcr.io
+          username: ${{ inputs.ghcr_package_owner_name }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       -
         name: check build files
@@ -176,7 +189,7 @@ jobs:
             *.platform=${{ matrix.platform }}
             *.cache-from=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
             *.cache-to=type=gha,scope=build-${{ env.PLATFORM_PAIR }}
-            *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
+            *.output=type=image,"name=${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }},ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}",push-by-digest=true,name-canonical=true
 
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
@@ -196,7 +209,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ inputs.push_remote_flag }}
         with:
-          name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
+          name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/*
           overwrite: true
           if-no-files-found: error
@@ -219,7 +232,7 @@ jobs:
       -
         name: check temp path
         run: |
-          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
 
       -
@@ -228,7 +241,7 @@ jobs:
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          pattern: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
           path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           merge-multiple: true
 
@@ -238,7 +251,7 @@ jobs:
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
-          pattern: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
+          pattern: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
           path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
           merge-multiple: true
 
@@ -260,13 +273,24 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ inputs.ghcr_package_owner_name }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
           docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+            $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
           tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
+          docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/sinlov/docker-lua-with-rakefile"
 
 # https://hub.docker.com/r/nickblah/lua/tags

--- a/build-alpine-local.dockerfile
+++ b/build-alpine-local.dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/sinlov/docker-lua-with-rakefile"
 
 # https://hub.docker.com/r/nickblah/lua/tags

--- a/build-alpine.dockerfile
+++ b/build-alpine.dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/sinlov/docker-lua-with-rakefile"
 
 # https://hub.docker.com/r/nickblah/lua/tags

--- a/build-debian.dockerfile
+++ b/build-debian.dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/sinlov/docker-lua-with-rakefile"
 
 # https://hub.docker.com/r/nickblah/lua/tags

--- a/build-ubuntu.dockerfile
+++ b/build-ubuntu.dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/sinlov/docker-lua-with-rakefile"
 
 # https://hub.docker.com/r/nickblah/lua/tags

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/sinlov/docker-lua-with-rakefile"
 
 # https://hub.docker.com/r/nickblah/lua/tags


### PR DESCRIPTION
…dx v6

feat #13

- Add new workflows for multi-platform builds and pushes to Docker Hub and GHCR
- Update existing workflows to use Docker Buildx v6 and add timeout configuration
- Add check steps to verify build files and metadata
- Implement matrix builds for different platforms
- Add support for pushing to both Docker Hub and GitHub Container Registry
